### PR TITLE
El test que pedia ocho cifras donde podia haber siete

### DIFF
--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -32,7 +32,9 @@ class TestUniqueSoundId:
         from bot import _generate_unique_sound_id
 
         new_id = await _generate_unique_sound_id(database)
-        assert 10_000_000 <= new_id <= 99_999_999
+        # 8-digit string of digits, joined and int()-ed: leading zeros disappear,
+        # so any value in [0, 99_999_999] is valid.
+        assert 0 <= new_id <= 99_999_999
         assert await database.get_sound(id=new_id) is None
 
     async def test_raises_when_no_id_available(self, database, monkeypatch):


### PR DESCRIPTION
## Resumen, breve

Hay quien dice que un test fallo en CI tras mergear el #42. Yo, sin entrar en valoraciones, prefiero que esto se cierre cuanto antes para que no tenga uno que estar pendiente.

`_generate_unique_sound_id` genera un id concatenando ocho digitos al azar. Cuando random saca un cero por delante (`0` `5` `5` `6` `6` `2` `3` `6`), `int()` se come el cero y el numero queda en siete cifras. Al bot le da igual, lo que necesita es unicidad. Pero el test pedia `>= 10_000_000` y, ese dia, no se lo pudimos dar.

## Cambio

Una linea en `tests/test_bot.py`: el rango valido es `[0, 99_999_999]`, no `[10_000_000, 99_999_999]`. Ajustamos el test, no la realidad.

## Test plan

- [x] `uv run --extra dev pytest` -> 55 passed
- [x] `uv run --extra dev ruff check` -> all checks passed

Una taza es una taza, y un id de siete cifras tambien es un id.